### PR TITLE
Remove llama3.1 from LiteLLM and seeder configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ LITELLM_UI_USERNAME=admin
 LITELLM_UI_PASSWORD=admin
 LITELLM_MASTER_KEY=sk-local-master
 OLLAMA_API_BASE=http://ollama:11434
-OLLAMA_SEED_MODELS=llama3.2,mistral,qwen2.5:7b
+OLLAMA_SEED_MODELS=llama3.2,mistral,qwen2.5
 OLLAMA_SEED_TIMEOUT=600
 
 # OpenAI/LiteLLM Configuration

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cd chatbot
 
 > **Note**: The Gradle tasks automatically create a `.env` file from `.env.example` if it doesn't exist. You can customize environment variables by editing the `.env` file.
 
-> **Ollama models**: A dedicated `ollama-seeder` service now preloads the Ollama models defined in `OLLAMA_SEED_MODELS` (default: `llama3.2,mistral,qwen2.5:7b`). Adjust this variable in your `.env` file if you need a different model set.
+> **Ollama models**: A dedicated `ollama-seeder` service now preloads the Ollama models defined in `OLLAMA_SEED_MODELS` (default: `llama3.2,mistral,qwen2.5`). Adjust this variable in your `.env` file if you need a different model set.
 
 ### 2. Run Backend
 

--- a/build.gradle
+++ b/build.gradle
@@ -231,9 +231,9 @@ task rebuild {
 task ollamaInstallModels {
     group = 'ollama'
     description = 'Installs common Ollama models (llama3.2, mistral, qwen2.5)'
-    
+
     doLast {
-        def models = ['llama3.2', 'llama3.1', 'mistral', 'qwen2.5:7b']
+        def models = ['llama3.2', 'mistral', 'qwen2.5']
         models.each { model ->
             println "Installing Ollama model: ${model}"
             try {

--- a/config/litellm.config.yaml
+++ b/config/litellm.config.yaml
@@ -9,12 +9,6 @@ model_list:
       api_base: http://ollama:11434
       keep_alive: "8m"  # Keep model in RAM for 8 minutes
       
-  - model_name: llama3.1
-    litellm_params:
-      model: ollama_chat/llama3.1
-      api_base: http://ollama:11434
-      keep_alive: "8m"
-      
   - model_name: mistral
     litellm_params:
       model: ollama_chat/mistral

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
       OLLAMA_HOST: ${OLLAMA_HOST:-ollama}
       OLLAMA_PORT: ${OLLAMA_PORT:-11434}
       OLLAMA_API_BASE: ${OLLAMA_API_BASE:-http://ollama:11434}
-      OLLAMA_SEED_MODELS: ${OLLAMA_SEED_MODELS:-llama3.2,mistral,qwen2.5:7b}
+      OLLAMA_SEED_MODELS: ${OLLAMA_SEED_MODELS:-llama3.2,mistral,qwen2.5}
       OLLAMA_SEED_TIMEOUT: ${OLLAMA_SEED_TIMEOUT:-600}
     depends_on:
       ollama:

--- a/docker/ollama-seeder/seed-models.sh
+++ b/docker/ollama-seeder/seed-models.sh
@@ -13,7 +13,7 @@ OLLAMA_HOST="${OLLAMA_HOST:-ollama}"
 OLLAMA_PORT="${OLLAMA_PORT:-11434}"
 OLLAMA_BASE_URL="${OLLAMA_API_BASE:-http://${OLLAMA_HOST}:${OLLAMA_PORT}}"
 SEED_TIMEOUT="${OLLAMA_SEED_TIMEOUT:-600}"
-MODELS_RAW="${OLLAMA_SEED_MODELS:-llama3.2,mistral,qwen2.5:7b}"
+MODELS_RAW="${OLLAMA_SEED_MODELS:-llama3.2,mistral,qwen2.5}"
 
 # Normalize models list (commas or whitespace) and remove empty entries
 IFS=',' read -ra MODELS_FROM_COMMAS <<< "${MODELS_RAW// /,}"


### PR DESCRIPTION
## Summary
- remove the llama3.1 entry from the LiteLLM model configuration
- align the Ollama seeder defaults and helper task with the LiteLLM model list
- update documentation and environment defaults to reflect the matched model set

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f10cee6bc832692d8d06cbb3433c9)